### PR TITLE
feat: wallet request flow

### DIFF
--- a/src/Web3Auth.ts
+++ b/src/Web3Auth.ts
@@ -1230,6 +1230,10 @@ class Web3Auth implements IWeb3Auth {
       verifierId: userId,
     });
 
+    // Hermes-safe recordId so torus.js uses /v1/auth/audit instead of generating one via crypto.randomUUID.
+    const recordId = generateRecordId();
+    const authConnection = loginParams.authConnection;
+
     let retrieveSharesResponse: TorusKey;
 
     if (subVerifierInfoArray && subVerifierInfoArray.length > 0) {
@@ -1263,6 +1267,8 @@ class Web3Auth implements IWeb3Auth {
         verifier: loginParams.authConnectionId,
         verifierParams: verifierParams,
         idToken: aggregateIdToken,
+        recordId,
+        authConnection,
       });
     } else {
       const verifierParams: VerifierParams = {
@@ -1275,6 +1281,8 @@ class Web3Auth implements IWeb3Auth {
         verifier: loginParams.authConnectionId,
         verifierParams: verifierParams,
         idToken: loginParams.idToken,
+        recordId,
+        authConnection,
       });
     }
 

--- a/src/Web3Auth.ts
+++ b/src/Web3Auth.ts
@@ -2,7 +2,7 @@ import { createKeyPairFromBytes } from "@solana/keys";
 import { createSignerFromKeyPair, type TransactionSigner } from "@solana/signers";
 import { CITADEL_SERVER_MAP, STORAGE_SERVER_MAP, STORAGE_SERVER_SOCKET_URL_MAP } from "@toruslabs/constants";
 import { NodeDetailManager } from "@toruslabs/fetch-node-details";
-import { add0x, type Hex } from "@toruslabs/metadata-helpers";
+import { add0x, type Hex, remove0x } from "@toruslabs/metadata-helpers";
 import { AuthSessionManager, StorageManager } from "@toruslabs/session-manager";
 import { keccak256, Torus, TorusKey, VerifierParams } from "@toruslabs/torus.js";
 import {
@@ -199,7 +199,7 @@ class Web3Auth implements IWeb3Auth {
 
   private get walletSdkUrl(): string {
     if (!this.addVersionInUrls) return `${this.options.walletSdkURL}`;
-    return `${this.options.walletSdkURL}/v5`;
+    return `${this.options.walletSdkURL}/v6`;
   }
 
   private get dashboardUrl(): string {
@@ -530,9 +530,11 @@ class Web3Auth implements IWeb3Auth {
       const sessionId = this.currentSessionId;
       const isSFA = await this.checkIsSFAFromStorage();
 
+      // Wallet v5 session-manager rejects 0x-prefixed keys ("Bad private key: expected 32 bytes, got 0").
+      // Staging still uses the original loginId; hash params are unprefixed for cross-version authorizeSession.
       const configParams: WalletLoginParams = {
-        loginId,
-        sessionId,
+        loginId: remove0x(loginId),
+        sessionId: remove0x(sessionId),
         // SFA has no citadel token; wallet falls back to session-service auth.
         accessToken: isSFA ? undefined : ((await this.sessionManager.getAccessToken()) ?? undefined),
         platform: "react-native",
@@ -601,9 +603,10 @@ class Web3Auth implements IWeb3Auth {
 
       const sessionId = this.currentSessionId;
       const isSFA = await this.checkIsSFAFromStorage();
+      // See launchWalletServices: unprefixed ids for wallet session-manager compatibility.
       const configParams: WalletLoginParams = {
-        loginId,
-        sessionId,
+        loginId: remove0x(loginId),
+        sessionId: remove0x(sessionId),
         accessToken: isSFA ? undefined : ((await this.sessionManager.getAccessToken()) ?? undefined),
         request: {
           method,

--- a/src/Web3Auth.ts
+++ b/src/Web3Auth.ts
@@ -533,8 +533,12 @@ class Web3Auth implements IWeb3Auth {
       const configParams: WalletLoginParams = {
         loginId,
         sessionId,
+        // SFA has no citadel token; wallet falls back to session-service auth.
+        accessToken: isSFA ? undefined : ((await this.sessionManager.getAccessToken()) ?? undefined),
         platform: "react-native",
         sessionNamespace: isSFA ? "sfa" : undefined,
+        recordId: generateRecordId(),
+        loginSource: "web3auth-react-native",
       };
 
       const loginUrl = constructURL({
@@ -600,12 +604,15 @@ class Web3Auth implements IWeb3Auth {
       const configParams: WalletLoginParams = {
         loginId,
         sessionId,
+        accessToken: isSFA ? undefined : ((await this.sessionManager.getAccessToken()) ?? undefined),
         request: {
           method,
           params,
         },
         platform: "react-native",
         sessionNamespace: isSFA ? "sfa" : undefined,
+        recordId: generateRecordId(),
+        loginSource: "web3auth-react-native",
       };
 
       const loginUrl = constructURL({

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -98,12 +98,15 @@ export interface IWeb3Auth {
 export type WalletLoginParams = {
   loginId: string;
   sessionId: string;
+  accessToken?: string; // citadel session auth; absent for SFA (session-service)
   request?: {
     method: string;
     params: unknown[];
   };
   platform: string;
   sessionNamespace?: string;
+  recordId?: string;
+  loginSource?: string;
 };
 
 export type SmartAccountType = (typeof SMART_ACCOUNT)[keyof typeof SMART_ACCOUNT];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

After the SDK v11 citadel session migration, launchWalletServices and request still sent a minimal WalletLoginParams payload to the wallet embed. Other auth flows (openAuthSession) already include citadel accessToken, recordId, and loginSource, so wallet flows were inconsistent and could not authenticate citadel sessions correctly.

This change aligns wallet UI and RPC request flows with the rest of the v11 auth stack.

Jira Link:


## Description
<!--- Describe your changes in detail -->

Extends WalletLoginParams and the wallet URL hash encoding in launchWalletServices and request to match openAuthSession:

- accessToken - included for non-SFA (citadel) sessions; omitted for SFA so the wallet falls back to session-service auth
- recordId - generated per request via generateRecordId() for analytics/tracing
- loginSource - set to "web3auth-react-native" for platform identification
- WalletLoginParams type updated to document the new optional fields.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My code requires a db migration.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches wallet authentication (citadel tokens, session IDs) and bumps the wallet SDK version; misconfiguration could break wallet UI or RPC request flows for logged-in users.
> 
> **Overview**
> Aligns **wallet embed** and **RPC `request`** flows with the rest of the v11 citadel stack so citadel sessions can authenticate in the wallet the same way as `openAuthSession`.
> 
> **Wallet URL & hash params:** Production wallet base path moves from **`/v5` → `/v6`**. `loginId` and `sessionId` in the wallet hash are sent **without** the `0x` prefix so the wallet session-manager accepts them. For non-SFA users, **`accessToken`** is included; SFA omits it so the wallet uses session-service auth. Each open adds **`recordId`** and **`loginSource: "web3auth-react-native"`**, matching other auth entry points.
> 
> **Types:** `WalletLoginParams` documents the new optional **`accessToken`**, **`recordId`**, and **`loginSource`** fields.
> 
> **SFA / Torus:** `getTorusKey` passes a Hermes-safe **`recordId`** and **`authConnection`** into `retrieveShares` so audit uses `/v1/auth/audit` instead of `crypto.randomUUID` on React Native.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbee4f9e320d50dfc07e2f768d1544daffb1f7de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->